### PR TITLE
Add start trigger command

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ command="/usr/bin/rtui" ssh-ed25519 AAAA....
 - `mode`: Get or set the current robot mode (COMP or DEV)
 - `quit`: Leave the terminal session.
 - `restart`: Restart running code
+- `start`: Trigger the virtual start button
+- `trigger`: Trigger the virtual start button
 - `zone`: Get or set the current zone
 
 

--- a/rtui/astoria.py
+++ b/rtui/astoria.py
@@ -9,9 +9,11 @@ from astoria.common.ipc import (
     ManagerRequest,
     MetadataManagerMessage,
     MetadataSetManagerRequest,
+    StartButtonBroadcastEvent,
     UsercodeLogBroadcastEvent,
 )
 from astoria.common.metadata import Metadata
+from astoria.common.mqtt import BroadcastHelper
 from prompt_toolkit import print_formatted_text
 from pydantic import ValidationError, parse_obj_as
 
@@ -109,6 +111,14 @@ class AstoriaIntegration(StateConsumer):
             print_formatted_text("Unable to restart code.")
             if len(res.reason) > 0:
                 print_formatted_text(res.reason)
+
+    async def trigger_start(self) -> None:
+        """Trigger the virtual start button."""
+        event = BroadcastHelper.get_helper(
+            self._mqtt,
+            StartButtonBroadcastEvent,
+        )
+        event.send()
 
     async def mutate_metadata(self, attr: str, value: str) -> None:
         """

--- a/rtui/commands/__init__.py
+++ b/rtui/commands/__init__.py
@@ -8,6 +8,7 @@ from .kill import KillUsercodeCommand
 from .metadata import ArenaCommand, MetadataCommand, ModeCommand, ZoneCommand
 from .quit import QuitCommand
 from .restart import RestartUsercodeCommand
+from .start import StartTriggerCommand
 
 COMMANDS: Dict[str, Type[BaseCommand]] = {
     "arena": ArenaCommand,
@@ -18,6 +19,8 @@ COMMANDS: Dict[str, Type[BaseCommand]] = {
     "mode": ModeCommand,
     "quit": QuitCommand,
     "restart": RestartUsercodeCommand,
+    "start": StartTriggerCommand,
+    "trigger": StartTriggerCommand,
     "zone": ZoneCommand,
 }
 

--- a/rtui/commands/start.py
+++ b/rtui/commands/start.py
@@ -1,0 +1,14 @@
+"""Command to trigger the virtual start button."""
+from typing import List
+
+from .command import BaseCommand
+
+
+class StartTriggerCommand(BaseCommand):
+    """Trigger the start button."""
+
+    description = "Trigger the virtual start button."
+
+    async def exec(self, args: List[str]) -> None:
+        """Execute the command."""
+        await self._tui.astoria.trigger_start()


### PR DESCRIPTION
Adding a start trigger command, both `start` and an alias of `trigger` to match the astctl command.

Fixes #4